### PR TITLE
Remove required quotes in content-disposition header

### DIFF
--- a/src/common/CFClient.js
+++ b/src/common/CFClient.js
@@ -70,7 +70,7 @@ class CFClient {
                     const downloadDirNormalized = path.normalize(downloadDir);
                     if (contentDisposition) {
                         const defaultName = `garmin_connect_download_${Date.now()}`;
-                        const [, fileName = defaultName] = contentDisposition.match(/filename="(.+)"/);
+                        const [, fileName = defaultName] = contentDisposition.match(/filename=(.+)/);
                         const filePath = path.resolve(downloadDirNormalized, fileName);
                         fs.writeFileSync(filePath, body);
                         resolve(filePath);

--- a/src/common/CFClient.js
+++ b/src/common/CFClient.js
@@ -70,7 +70,7 @@ class CFClient {
                     const downloadDirNormalized = path.normalize(downloadDir);
                     if (contentDisposition) {
                         const defaultName = `garmin_connect_download_${Date.now()}`;
-                        const [, fileName = defaultName] = contentDisposition.match(/filename=(.+)/);
+                        const [, fileName = defaultName] = contentDisposition.match(/filename="?([^"]+)"?/);
                         const filePath = path.resolve(downloadDirNormalized, fileName);
                         fs.writeFileSync(filePath, body);
                         resolve(filePath);


### PR DESCRIPTION
When trying to download a TCX file, I was facing errors like this:

```
(node:4767) UnhandledPromiseRejectionWarning: TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
```

and the stack trace pointed to this line.

I logged the response here and found this header did not include quotes for the activities from my account. Example observed header value:
```
'content-disposition': 'attachment; filename=activity_8627651372.tcx'
```

I removed the quotes on this line and the TCX download began working as expected.

Thank you for creating this library!