### PR TITLE
fix: activity upload

### DIFF
--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -407,16 +407,21 @@ export default class GarminConnect {
      */
     async uploadActivity(file: string, format: UploadFileType) {
         const detectedFormat = (format || path.extname(file))?.toLowerCase();
+        const filename = path.basename(file);
 
         if ((<any>Object).values(UploadFileType).includes(detectedFormat)) {
             return Promise.reject();
         }
 
-        const fileBinary = fs.createReadStream(file);
+        const fileBuffer = fs.readFileSync(file);
         const response = this.client.post(urls.upload(format), {
-            file: fileBinary
+            userfile: {
+                value: fileBuffer,
+                options: {
+                    filename
+                }
+            }
         });
-        fileBinary.close();
         return response;
     }
 


### PR DESCRIPTION
- changed api form specs
- changed formdata creation

Hi! I tried using your lib, but I couldn't upload an activity. First thing I noticed, is that the name of the formdata value is different:
![image](https://user-images.githubusercontent.com/7596740/217717922-a2e27519-edf7-4818-b6ba-2594712c21fa.png)
(used to be just `file`)
But also for some reason it kept breaking for me, until I changed the way the formData is built, following the request.js docs as seen [here](https://github.com/request/request#forms) under `custom_file`.

Works for me now :D