### PR TITLE
Fix readme how to use example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const { GarminConnect } = require('garmin-connect');
 // Create a new Garmin Connect Client
 const GCClient = new GarminConnect();
 // Uses credentials from garmin.config.json or uses supplied params
-await GCClient.login('my.email@example.com', 'MySecretPassword');
+await GCClient.login({"username": "my.email@example.com", "password": "MySecretPassword"});
 const userInfo = await GCClient.getUserInfo();
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ $ npm install garmin-connect
 ```js
 const { GarminConnect } = require('garmin-connect');
 // Create a new Garmin Connect Client
-const GCClient = new GarminConnect();
+const GCClient = new GarminConnect({"username": "my.email@example.com", "password": "MySecretPassword"});
 // Uses credentials from garmin.config.json or uses supplied params
-await GCClient.login({"username": "my.email@example.com", "password": "MySecretPassword"});
+await GCClient.login();
 const userInfo = await GCClient.getUserInfo();
 ```
 


### PR DESCRIPTION
Credentials need to be passed to the constructor as an object. Otherwise it will still attempt to use the credentials from garmin.config.json and fail if that file does not exist.