### PR TITLE
Re-add "getSteps" API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "garmin-connect",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Makes it simple to interface with Garmin Connect to get or set any data point",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -62,6 +62,9 @@ export class UrlClass {
     get IMPORT_DATA() {
         return `${this.GC_API}/modern/import-data`;
     }
+    get DAILY_STEPS() {
+        return `${this.GC_API}/usersummary-service/stats/steps/daily/`;
+    }
     WORKOUT(id?: GCWorkoutId) {
         if (id) {
             return `${this.GC_API}/workout-service/workout/${id}`;

--- a/src/garmin/common/DateUtils.ts
+++ b/src/garmin/common/DateUtils.ts
@@ -1,0 +1,6 @@
+export function toDateString(date: Date) {
+    const offset = date.getTimezoneOffset();
+    const offsetDate = new Date(date.getTime() - offset * 60 * 1000);
+    const [dateString] = offsetDate.toISOString().split('T');
+    return dateString;
+}

--- a/src/garmin/types.ts
+++ b/src/garmin/types.ts
@@ -850,3 +850,12 @@ export interface ITargetType {
     workoutTargetTypeKey: string;
     displayOrder: number;
 }
+
+// IDailySummary
+
+export interface IDailyStepsType {
+    calendarDate: string;
+    stepGoal: number;
+    totalDistance: number;
+    totalSteps: number;
+}


### PR DESCRIPTION
The new version 1.6.0 removed the "getSteps" API. I am re-adding it using the same daily summary as the Garmin Connect online dashboard. 