### PR TITLE
add a function to download wellness data

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,24 @@ const id = workouts[0].workoutId;
 GCClient.deleteWorkout({ workoutId: id });
 ```
 
+### ` downloadWellnessData(date: Date, dir: string):void`
+
+Download daily wellness data, such as heart rate, HRV, stress, sleep, breathing, etc.
+
+#### Parameters:
+
+-   `date` (Date, optional): Date of information requested. Defaults to the current date.
+-   `dir` (String, require): a directory path where you want to save the file
+
+#### Example:
+
+```js
+await GCClient.downloadWellnessData(
+    new Date('2023-01-11'),
+    'a directory path where you want to save the file'
+);
+```
+
 ## Custom requests
 
 This library will handle custom requests to your active Garmin Connect session. There are a lot of different url's that is used, which means that this library probably wont cover them all. By using the network analyze tool you can find url's that are used by Garmin Connect to fetch data.

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -224,18 +224,22 @@ export default class GarminConnect {
         );
     }
 
-    async downloadWellnessData(date: Date, dir: string) {
+    async downloadWellnessData(date = new Date(), dir: string) {
         const dateStr = toDateString(date);
         if (!checkIsDirectory(dir)) {
             createDirectory(dir);
         }
-        let fileBuffer = await this.client.get<Buffer>(
-            this.url.DOWNLOAD_WELLNESS + dateStr,
-            {
-                responseType: 'arraybuffer'
-            }
-        );
-        writeToFile(path.join(dir, `${dateStr}.zip`), fileBuffer);
+        try {
+            let fileBuffer = await this.client.get<Buffer>(
+                this.url.DOWNLOAD_WELLNESS + dateStr,
+                {
+                    responseType: 'arraybuffer'
+                }
+            );
+            writeToFile(path.join(dir, `${dateStr}.zip`), fileBuffer);
+        } catch (e) {
+            console.log('Get wellness data failed: ' + e);
+        }
     }
 
     async uploadActivity(

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -224,6 +224,20 @@ export default class GarminConnect {
         );
     }
 
+    async downloadWellnessData(date: Date, dir: string) {
+        const dateStr = toDateString(date);
+        if (!checkIsDirectory(dir)) {
+            createDirectory(dir);
+        }
+        let fileBuffer = await this.client.get<Buffer>(
+            this.url.DOWNLOAD_WELLNESS + dateStr,
+            {
+                responseType: 'arraybuffer'
+            }
+        );
+        writeToFile(path.join(dir, `${dateStr}.zip`), fileBuffer);
+    }
+
     async uploadActivity(
         file: string,
         format: UploadFileTypeTypeValue = 'fit'

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -56,6 +56,9 @@ export class UrlClass {
     get DOWNLOAD_KML() {
         return `${this.GC_API}/download-service/export/kml/activity/`;
     }
+    get DOWNLOAD_WELLNESS() {
+        return `${this.GC_API}/download-service/files/wellness/`;
+    }
     get UPLOAD() {
         return `${this.GC_API}/upload-service/upload/`;
     }


### PR DESCRIPTION
function downloadWellnessData can download a zip file.
This zip file contains all the fit files for health data, such as heart rate, HRV, stress, sleep, breathing, etc. This api can get almost all wellness data, but I don't test every itme.
These files can be directly synchronized to other Garmin account through methods  uploadActivity