### PR TITLE
Fix Running activity type

### DIFF
--- a/src/garmin/types/activity.ts
+++ b/src/garmin/types/activity.ts
@@ -7,7 +7,7 @@ export enum ActivityType {
     Hiking = 'hiking',
     Other = 'other',
     WaterSport = 'water_sports',
-    Running = 'street_running'
+    Running = 'running'
 }
 
 export enum ActivitySubType {


### PR DESCRIPTION
Minor fix to for `Running` activity type since it was defined as `street_running` but it needs to be `running` instead. 

**BEFORE**

**Request**

```
app.get("/activities", async (_, res: Response) => {
  try {
    const activities = await GCClient.getActivities(
      0,
      10,
      ActivityType.Running // "running_outdoor"
    );
    res.status(200).send(JSON.stringify(activities));
  } catch (e) {
    res.status(400).send(e);
  }
});
```

**Response:**

```
ERROR: (400), Bad Request, {"message":"Activity type cannot be an activity sub type","error":"BadRequestException"}
```

<img width="621" alt="Screenshot 2024-06-23 at 21 47 14" src="https://github.com/Pythe1337N/garmin-connect/assets/32987464/e8592e5b-fc14-4803-8e3f-00cdfedb4848">



**AFTER**

**Request**

```
app.get("/activities", async (_, res: Response) => {
  try {
    const activities = await GCClient.getActivities(
      0,
      10,
      "running"
    );
    res.status(200).send(JSON.stringify(activities));
  } catch (e) {
    res.status(400).send(e);
  }
});
```

**Response:**

<img width="596" alt="Screenshot 2024-06-23 at 21 46 53" src="https://github.com/Pythe1337N/garmin-connect/assets/32987464/169bbf5c-416f-4a37-a0d0-b7e8bd9e6b5f">


