### PR TITLE
Fix `getLocalTimestamp`

### DIFF
--- a/src/garmin/common/DateUtils.ts
+++ b/src/garmin/common/DateUtils.ts
@@ -24,18 +24,18 @@ export function calculateTimeDifference(
 }
 
 export function getLocalTimestamp(date: Date, timezone: string) {
-    // Get the current local date timestamp in ISO format
-    const localTimestampISO = date.toISOString().substring(0, 23);
-
-    // Convert the ISO timestamp to local timezone while maintaining the same format
-    const localTimestamp = new Date(localTimestampISO).toLocaleString('en-US', {
+    // Format the local date as `YYYY-MM-DD`
+    const formatted_date = date.toLocaleDateString('sv', {
+        timeZone: timezone
+    });
+    // Format the local time as `HH:MM:SS`
+    const formatted_time = date.toLocaleTimeString('sv', {
         timeZone: timezone,
         hour12: false
     });
+    // Format millseconds
+    const formatted_mill_sec = String(date.getMilliseconds()).padStart(3, '0');
 
     // Format the local timestamp as `YYYY-MM-DDTHH:MM:SS.SSS`
-    const formattedLocalTimestamp = new Date(localTimestamp)
-        .toISOString()
-        .substring(0, 23);
-    return formattedLocalTimestamp;
+    return `${formatted_date}T${formatted_time}.${formatted_mill_sec}`;
 }


### PR DESCRIPTION
Hi, I noticed that the implementation of the `getLocalTimestamp` method used in `updateWeight` seems problematic. As I understand it, this method is intended to generate an ISO format event string for a specified timezone. Taking `America/Los_Angeles` (GMT-8) as an example, for the UTC time `2024-12-10T18:00:00.000Z`, the expected result should be `2024-12-10T10:00:00.000`. However, the method currently returns `2024-12-09T18:00:00.000`. As a result, the recorded date in Garmin Connect is December 9th, and the time is incorrect.

To address this, I have reimplemented the method. For the same case, the result will now be `2024-12-10T10:00:00.000`.

The `sv` language was chosen because Swedish uses ISO strings as its time representation format.