### PR TITLE
Add device sync functionality for pushing workouts to Garmin devices

### DIFF
--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -22,7 +22,10 @@ import {
     IWorkout,
     IWorkoutDetail,
     UploadFileType,
-    UploadFileTypeTypeValue
+    UploadFileTypeTypeValue,
+    IDevice,
+    IDeviceMessage,
+    IWorkoutDevice
 } from './types';
 import Running from './workouts/Running';
 import {
@@ -548,5 +551,118 @@ export default class GarminConnect {
     async put<T>(url: string, data: any) {
         const response = await this.client.put<T>(url, data, {});
         return response as T;
+    }
+
+    // Device management methods
+    /**
+     * Get all connected devices
+     */
+    async getDevices(): Promise<IDevice[]> {
+        try {
+            const devices = await this.client.get<IDevice[]>(this.url.DEVICES);
+            return devices || [];
+        } catch (error: any) {
+            throw new Error(`Error getting devices: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get workout-capable devices only
+     */
+    async getWorkoutDevices(): Promise<IDevice[]> {
+        const devices = await this.getDevices();
+        return devices.filter(device => 
+            (device as any).workoutCapable === true
+        );
+    }
+
+    /**
+     * Push workout to a specific device
+     */
+    async pushWorkoutToDevice(
+        workout: { workoutId: string }, 
+        deviceId: string,
+        workoutName?: string
+    ): Promise<any> {
+        if (!workout.workoutId) {
+            throw new Error('Missing workoutId');
+        }
+
+        // Based on real Garmin Connect API from research
+        const message = {
+            deviceId: parseInt(deviceId),
+            messageUrl: `workout-service/workout/FIT/${workout.workoutId}`,
+            messageType: 'workouts',
+            messageName: workoutName || 'Training Workout',
+            groupName: null,
+            priority: 1,
+            fileType: 'FIT',
+            metaDataId: parseInt(workout.workoutId)
+        };
+
+        try {
+            const response = await this.client.post(
+                this.url.DEVICE_MESSAGES,
+                [message] // API expects an array
+            );
+
+            console.log('✅ Workout pushed to device:', {
+                workoutId: workout.workoutId,
+                deviceId: deviceId,
+                workoutName: message.messageName
+            });
+
+            return response;
+        } catch (error: any) {
+            console.error('❌ Failed to push workout to device:', error);
+            throw new Error(`Error pushing workout to device: ${error.message}`);
+        }
+    }
+
+    /**
+     * Push workout to all workout-capable devices
+     */
+    async pushWorkoutToAllDevices(
+        workout: { workoutId: string },
+        workoutName?: string
+    ): Promise<any[]> {
+        const devices = await this.getWorkoutDevices();
+        
+        if (devices.length === 0) {
+            throw new Error('No workout-capable devices found');
+        }
+
+        const results = await Promise.all(
+            devices.map(device =>
+                this.pushWorkoutToDevice(workout, device.deviceId, workoutName)
+            )
+        );
+
+        return results;
+    }
+
+    /**
+     * Get device messages/sync status
+     */
+    async getDeviceMessages(deviceId?: string): Promise<IDeviceMessage[]> {
+        try {
+            const params = deviceId ? { deviceId } : {};
+            const response = await this.client.get(
+                this.url.DEVICE_MESSAGES,
+                { params }
+            );
+            
+            // Ensure we return an array
+            if (Array.isArray(response)) {
+                return response;
+            } else if (response && (response as any).messages && Array.isArray((response as any).messages)) {
+                return (response as any).messages;
+            } else {
+                return [];
+            }
+        } catch (error: any) {
+            console.log('No device messages found or error:', error.message);
+            return [];
+        }
     }
 }

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -98,4 +98,15 @@ export class UrlClass {
     get WORKOUTS() {
         return `${this.GC_API}/workout-service/workouts`;
     }
+
+    // Device sync endpoints based on real Garmin Connect API
+    get DEVICES() {
+        return `${this.GC_API}/device-service/deviceregistration/devices`;
+    }
+
+    get DEVICE_MESSAGES() {
+        return `${this.GC_API}/device-service/devicemessage/messages`;
+    }
 }
+
+

--- a/src/garmin/types/index.ts
+++ b/src/garmin/types/index.ts
@@ -471,3 +471,70 @@ export interface IDailyStepsType {
     totalDistance: number;
     totalSteps: number;
 }
+
+export type GCDeviceId = string;
+
+export interface IDeviceCapabilities {
+    accelerometer?: boolean;
+    activityDetection?: boolean;
+    appTypes?: string[];
+    bluetoothClassicSupported?: boolean;
+    bluetoothLowEnergySupported?: boolean;
+    dataFieldTypes?: string[];
+    gps?: boolean;
+    heartRateMonitor?: boolean;
+    swimProof?: boolean;
+    touchScreen?: boolean;
+    wifiCapable?: boolean;
+    workoutFeatures?: string[];
+}
+
+export interface IDevice {
+    deviceId: GCDeviceId;
+    displayName: string;
+    deviceTypePk: number;
+    deviceTypeDisplayName: string;
+    batteryStatus?: string;
+    batteryLevel?: number;
+    lastSyncTime?: string;
+    firmwareVersion?: string;
+    capabilities?: IDeviceCapabilities;
+    softwareVersion?: string;
+    partnumber?: string;
+    primaryDevice?: boolean;
+    imageName?: string;
+    smallImageName?: string;
+    largeImageName?: string;
+    connectionType?: 'BLUETOOTH' | 'WIFI' | 'USB';
+    bluetoothAddress?: string;
+    softwareUpdateAvailable?: boolean;
+    syncCapable?: boolean;
+}
+
+export interface IDeviceMessage {
+    messageId?: string;
+    deviceId: GCDeviceId;
+    messageType: string;
+    groupType?: string;
+    fileType?: string;
+    priority?: number;
+    data?: any;
+    createdDate?: string;
+    delivered?: boolean;
+    processed?: boolean;
+}
+
+export interface IWorkoutDevice {
+    workoutId: string;
+    deviceId: GCDeviceId;
+    messageType: 'WORKOUT';
+    groupType: 'FITNESS';
+    fileType: 'WORKOUT';
+    priority: number;
+    data: {
+        workoutId: string;
+        workoutName?: string;
+        sport?: string;
+    };
+}
+


### PR DESCRIPTION
Add device synchronization capabilities to enable automatic pushing of workouts to connected Garmin devices.

Features Added:
• Device discovery and filtering (getDevices, getWorkoutDevices) • Workout push to specific devices (pushWorkoutToDevice) • Bulk workout sync to all devices (pushWorkoutToAllDevices) • Device message status monitoring (getDeviceMessages) • Complete TypeScript type definitions for device management

API Integration:
• GET /device-service/deviceregistration/devices - Device discovery • POST /device-service/devicemessage/messages - Workout sync queue

Implementation Details:
• Added device management methods to GarminConnect class • Extended UrlClass with DEVICES and DEVICE_MESSAGES endpoints • Enhanced type system with IDevice, IDeviceMessage interfaces • Includes comprehensive error handling and logging

Testing:
• Successfully tested with real Garmin Connect credentials • Verified device discovery (Forerunner 235, 955, HRM-Pro Plus) • Confirmed workout creation and sync to multiple devices