### PR TITLE
feat: add wellness API endpoints and MFA support (v1.9.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# garmin-connect — CLAUDE.md
+
+## Build & development
+
+```bash
+npm install
+npm run build:windows    # Windows (tsc --build --clean && tsc)
+npm run build            # Linux/Mac
+npm run build:watch      # Watch mode
+```
+
+TypeScript output goes to `dist/`. The `prepack` script runs build automatically before `npm publish`.
+
+## Architecture
+
+```
+src/
+├── index.ts                    # Public exports
+├── utils.ts                    # File system helpers
+├── common/
+│   └── HttpClient.ts           # Axios-based HTTP client, OAuth1/2, login, MFA
+└── garmin/
+    ├── GarminConnect.ts        # Main client class — all public API methods
+    ├── UrlClass.ts             # All Garmin Connect API endpoint URLs
+    ├── common/
+    │   ├── DateUtils.ts        # Date formatting helpers
+    │   ├── HydrationUtils.ts   # ML ↔ oz conversion
+    │   └── WeightUtils.ts      # Grams ↔ pounds conversion
+    ├── types/
+    │   ├── index.ts            # Core types (OAuth, workouts, user profile)
+    │   ├── activity.ts         # Activity types and enums
+    │   ├── golf.ts             # Golf scorecard types
+    │   ├── heartrate.ts        # Heart rate types
+    │   ├── hydration.ts        # Hydration types
+    │   ├── sleep.ts            # Sleep data types
+    │   ├── weight.ts           # Weight types
+    │   └── wellness.ts         # Wellness types (UserSummary, HRV, Stress, etc.)
+    └── workouts/
+        ├── Running.ts
+        └── templates/
+            └── RunningTemplate.ts
+```
+
+## Key patterns
+
+-   **Authentication**: OAuth1 → OAuth2 exchange flow. Tokens auto-refresh via axios interceptor on 401. Use `exportCurrentTokens()` / `loadToken()` to persist tokens across sessions.
+-   **MFA**: `login()` throws `GarminMfaRequiredError` if 2FA is required. Call `resumeWithMfa(code)` to complete login.
+-   **Date params**: Methods accept `Date` objects or `'YYYY-MM-DD'` strings. Internally converted via `toDateString()`.
+-   **Domain support**: Constructor accepts `garmin.com` (default) or `garmin.cn`.
+
+## What was added in this PR
+
+### MFA support (`HttpClient.ts`)
+
+-   `GarminMfaRequiredError` — thrown by `login()` when Garmin requires 2FA
+-   `MfaLoginState` interface — holds CSRF token and signin URL for the MFA step
+-   `resumeWithMfa(mfaCode)` — submits the verification code and completes OAuth flow
+-   `handleMFA(html)` — detects MFA challenge pages and captures state
+
+### Wellness API endpoints (`UrlClass.ts` + `GarminConnect.ts`)
+
+New methods on `GarminConnect`:
+
+| Method                           | Returns                                                          |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `getUserSummary(date?)`          | `IUserSummary` — steps, calories, stress, distance, floors       |
+| `getBodyComposition(start, end)` | `IBodyCompositionData` — weight, BMI, body fat, muscle mass      |
+| `getHrvData(date?)`              | `IHrvData` — HRV last night, weekly avg, status                  |
+| `getStressData(date?)`           | `IStressData` — overall stress, rest/activity/stress percentages |
+| `getBodyBattery(start, end)`     | `IBodyBatteryData[]` — charged/drained values                    |
+| `getSpO2Data(date?)`             | `ISpO2Data` — blood oxygen saturation                            |
+| `getFitnessAge(date?)`           | `IFitnessAgeData` — fitness age                                  |
+| `getEnduranceScore(date?)`       | `IEnduranceScoreData` — endurance score                          |
+| `getRespirationData(date?)`      | `IRespirationData` — breathing rate                              |
+
+### New type file (`types/wellness.ts`)
+
+Full TypeScript interfaces for all wellness API responses.
+
+### Exported types (`index.ts`)
+
+All type files are now re-exported from the package root for convenient importing.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # garmin-connect
 
-## v1.6.0 refactor
+## v1.9.0
 
 TODO:
 
@@ -12,7 +12,7 @@ TODO:
 -   [x] Download Activity, countActivities, getActivities, getActivity, getUserProfile, getUserSettings
 -   [x] Upload Activity, delete Activity
 -   [ ] Implementation of other methods, such as Badge,Workout,Gear etc
--   [ ] Handle MFA
+-   [x] Handle MFA
 -   [x] Handle Account locked
 -   [ ] Unit test
 -   [ ] Listeners
@@ -472,6 +472,149 @@ Retrieves daily heart rate data for a given date.
 
 ```js
 const heartRateData = await GCClient.getHeartRate(new Date('2020-03-24'));
+```
+
+## Wellness API
+
+### `getUserSummary(date?: Date): Promise<IUserSummary>`
+
+Retrieves the daily user summary including steps, calories, active time, stress, and more.
+
+#### Parameters:
+
+-   `date` (Date, optional): Date of the summary requested; defaults to today.
+
+#### Example:
+
+```js
+const summary = await GCClient.getUserSummary(new Date('2024-01-15'));
+// summary.totalSteps, summary.activeKilocalories, summary.averageStressLevel, etc.
+```
+
+---
+
+### `getBodyComposition(startDate: Date | string, endDate: Date | string): Promise<IBodyCompositionData>`
+
+Retrieves body composition data (weight, BMI, body fat, muscle mass, etc.) for a date range.
+
+#### Example:
+
+```js
+const bodyComp = await GCClient.getBodyComposition('2024-01-01', '2024-01-31');
+```
+
+---
+
+### `getHrvData(date?: Date): Promise<IHrvData>`
+
+Retrieves Heart Rate Variability (HRV) data for a given date.
+
+#### Example:
+
+```js
+const hrv = await GCClient.getHrvData(new Date('2024-01-15'));
+// hrv.hrvSummary.lastNight, hrv.hrvSummary.weeklyAvg, etc.
+```
+
+---
+
+### `getStressData(date?: Date): Promise<IStressData>`
+
+Retrieves daily stress data for a given date.
+
+#### Example:
+
+```js
+const stress = await GCClient.getStressData(new Date('2024-01-15'));
+// stress.overallStressLevel, stress.restStressPercentage, etc.
+```
+
+---
+
+### `getBodyBattery(startDate: Date | string, endDate: Date | string): Promise<IBodyBatteryData[]>`
+
+Retrieves Body Battery energy levels for a date range.
+
+#### Example:
+
+```js
+const battery = await GCClient.getBodyBattery('2024-01-01', '2024-01-07');
+// battery[0].charged, battery[0].drained, etc.
+```
+
+---
+
+### `getSpO2Data(date?: Date): Promise<ISpO2Data>`
+
+Retrieves blood oxygen saturation (SpO2) data for a given date.
+
+#### Example:
+
+```js
+const spo2 = await GCClient.getSpO2Data(new Date('2024-01-15'));
+```
+
+---
+
+### `getFitnessAge(date?: Date): Promise<IFitnessAgeData>`
+
+Retrieves fitness age data for a given date.
+
+#### Example:
+
+```js
+const fitnessAge = await GCClient.getFitnessAge(new Date('2024-01-15'));
+```
+
+---
+
+### `getEnduranceScore(date?: Date): Promise<IEnduranceScoreData>`
+
+Retrieves endurance score data for a given date.
+
+#### Example:
+
+```js
+const endurance = await GCClient.getEnduranceScore(new Date('2024-01-15'));
+```
+
+---
+
+### `getRespirationData(date?: Date): Promise<IRespirationData>`
+
+Retrieves respiration rate data for a given date.
+
+#### Example:
+
+```js
+const respiration = await GCClient.getRespirationData(new Date('2024-01-15'));
+```
+
+---
+
+## MFA (Multi-Factor Authentication)
+
+If your Garmin account has MFA enabled, `login()` will throw a `GarminMfaRequiredError`. Catch it and call `resumeWithMfa()` with the verification code.
+
+```js
+import { GarminConnect, GarminMfaRequiredError } from 'garmin-connect';
+
+const GCClient = new GarminConnect({
+    username: 'my.email@example.com',
+    password: 'MySecretPassword'
+});
+
+try {
+    await GCClient.login();
+} catch (err) {
+    if (err instanceof GarminMfaRequiredError) {
+        // Prompt user for the 6-digit code from their authenticator app
+        const mfaCode = '123456';
+        await GCClient.resumeWithMfa(mfaCode);
+    } else {
+        throw err;
+    }
+}
 ```
 
 ## Modifying data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "garmin-connect",
-    "version": "1.6.2",
+    "version": "1.9.0",
     "description": "Makes it simple to interface with Garmin Connect to get or set any data point",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/common/HttpClient.ts
+++ b/src/common/HttpClient.ts
@@ -16,12 +16,13 @@ import {
     IOauth1Token,
     IOauth2Token
 } from '../garmin/types';
-const crypto = require('crypto');
+import * as crypto from 'crypto';
 
 const CSRF_RE = new RegExp('name="_csrf"\\s+value="(.+?)"');
 const TICKET_RE = new RegExp('ticket=([^"]+)"');
 const ACCOUNT_LOCKED_RE = new RegExp('var statuss*=s*"([^"]*)"');
 const PAGE_TITLE_RE = new RegExp('<title>([^<]*)</title>');
+const MFA_TICKET_RE = new RegExp('ticket=([^"]+)"');
 
 const USER_AGENT_CONNECTMOBILE = 'com.garmin.android.apps.connectmobile';
 const USER_AGENT_BROWSER =
@@ -33,12 +34,26 @@ const OAUTH_CONSUMER_URL =
 let isRefreshing = false;
 let refreshSubscribers: ((token: string) => void)[] = [];
 
+export class GarminMfaRequiredError extends Error {
+    constructor(public readonly loginState: MfaLoginState) {
+        super('MFA verification required');
+        this.name = 'GarminMfaRequiredError';
+    }
+}
+
+export interface MfaLoginState {
+    csrf: string;
+    signinUrl: string;
+    cookies: string[];
+}
+
 export class HttpClient {
     client: AxiosInstance;
     url: UrlClass;
     oauth1Token: IOauth1Token | undefined;
     oauth2Token: IOauth2Token | undefined;
     OAUTH_CONSUMER: IOauth1Consumer | undefined;
+    private _mfaLoginState: MfaLoginState | undefined;
 
     constructor(url: UrlClass) {
         this.url = url;
@@ -178,16 +193,62 @@ export class HttpClient {
      * @param username
      * @param password
      * @returns {Promise<HttpClient>}
+     * @throws {GarminMfaRequiredError} When MFA is required — call resumeWithMfa() after
      */
     async login(username: string, password: string): Promise<HttpClient> {
         await this.fetchOauthConsumer();
-        // Step1-3: Get ticket from page.
+        // Step1-3: Get ticket from page (may throw GarminMfaRequiredError)
         const ticket = await this.getLoginTicket(username, password);
         // Step4: Oauth1
         const oauth1 = await this.getOauth1Token(ticket);
-        // TODO: Handle MFA
-
         // Step 5: Oauth2
+        await this.exchange(oauth1);
+        return this;
+    }
+
+    /**
+     * Resume login after MFA verification
+     * @param mfaCode The 6-digit MFA code from authenticator app
+     * @returns {Promise<HttpClient>}
+     */
+    async resumeWithMfa(mfaCode: string): Promise<HttpClient> {
+        if (!this._mfaLoginState) {
+            throw new Error('No MFA login state — call login() first');
+        }
+        if (!this.OAUTH_CONSUMER) {
+            await this.fetchOauthConsumer();
+        }
+
+        const { csrf, signinUrl } = this._mfaLoginState;
+
+        // Submit MFA verification code
+        const mfaForm = new FormData();
+        mfaForm.append('mfa-code', mfaCode);
+        mfaForm.append('embed', 'true');
+        mfaForm.append('_csrf', csrf);
+        mfaForm.append('fromPage', 'setupEnterMfaCode');
+
+        const mfaResult = await this.post<string>(signinUrl, mfaForm, {
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Dnt: 1,
+                Origin: this.url.GARMIN_SSO_ORIGIN,
+                Referer: signinUrl,
+                'User-Agent': USER_AGENT_BROWSER
+            }
+        });
+
+        const ticketRegResult = TICKET_RE.exec(mfaResult);
+        if (!ticketRegResult) {
+            throw new Error(
+                'MFA verification failed — invalid code or expired session'
+            );
+        }
+        const ticket = ticketRegResult[1];
+        this._mfaLoginState = undefined;
+
+        // Continue normal OAuth flow
+        const oauth1 = await this.getOauth1Token(ticket);
         await this.exchange(oauth1);
         return this;
     }
@@ -269,8 +330,27 @@ export class HttpClient {
         return ticket;
     }
 
-    // TODO: Handle MFA
-    handleMFA(htmlStr: string): void {}
+    handleMFA(htmlStr: string): void {
+        // Detect MFA challenge page — Garmin shows a page with "Verify Your Identity"
+        // or "Enter MFA Code" when 2FA is enabled
+        if (
+            htmlStr.includes('verifyMFA') ||
+            htmlStr.includes('setupEnterMfaCode') ||
+            htmlStr.includes('mfa-code')
+        ) {
+            // Extract CSRF token from MFA page
+            const csrfMatch = CSRF_RE.exec(htmlStr);
+            const csrf = csrfMatch ? csrfMatch[1] : '';
+
+            this._mfaLoginState = {
+                csrf,
+                signinUrl: `${this.url.SIGNIN_URL}`,
+                cookies: []
+            };
+
+            throw new GarminMfaRequiredError(this._mfaLoginState);
+        }
+    }
 
     // TODO: Handle Phone number
     handlePageTitle(htmlStr: string): void {

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -31,6 +31,10 @@ import {
     toDateString
 } from './common/DateUtils';
 import { SleepData } from './types/sleep';
+import { WeightData, UpdateWeight } from './types/weight';
+import { HeartRate } from './types/heartrate';
+import { HydrationData, WaterIntake } from './types/hydration';
+import { GolfSummary, GolfScorecard } from './types/golf';
 import { gramsToPounds } from './common/WeightUtils';
 import { convertMLToOunces, convertOuncesToML } from './common/HydrationUtils';
 import {
@@ -39,6 +43,17 @@ import {
     GCActivityId,
     IActivity
 } from './types/activity';
+import {
+    IUserSummary,
+    IBodyCompositionData,
+    IHrvData,
+    IStressData,
+    IBodyBatteryData,
+    ISpO2Data,
+    IFitnessAgeData,
+    IEnduranceScoreData,
+    IRespirationData
+} from './types/wellness';
 
 let config: GCCredentials | undefined = undefined;
 
@@ -67,6 +82,7 @@ export interface Session {}
 export default class GarminConnect {
     client: HttpClient;
     private _userHash: GCUserHash | undefined;
+    private _displayName: string | undefined;
     private credentials: GCCredentials;
     private listeners: Listeners;
     private url: UrlClass;
@@ -95,6 +111,22 @@ export default class GarminConnect {
             this.credentials.password
         );
         return this;
+    }
+
+    async resumeWithMfa(mfaCode: string): Promise<GarminConnect> {
+        await this.client.resumeWithMfa(mfaCode);
+        return this;
+    }
+
+    async getDisplayName(): Promise<string> {
+        if (this._displayName) return this._displayName;
+        const profile = await this.getUserProfile();
+        this._displayName = profile.displayName;
+        return this._displayName;
+    }
+
+    setDisplayName(name: string): void {
+        this._displayName = name;
     }
     exportTokenToFile(dirPath: string): void {
         if (!checkIsDirectory(dirPath)) {
@@ -534,6 +566,84 @@ export default class GarminConnect {
             throw new Error(`Error in getHeartRate: ${error.message}`);
         }
     }
+
+    // ─── Wellness API Methods ────────────────────────────────────
+
+    async getUserSummary(date = new Date()): Promise<IUserSummary> {
+        const dateString = toDateString(date);
+        const displayName = await this.getDisplayName();
+        return this.client.get<IUserSummary>(
+            `${this.url.USER_SUMMARY}/${displayName}`,
+            { params: { calendarDate: dateString, _: Date.now() } }
+        );
+    }
+
+    async getBodyComposition(
+        startDate: Date | string,
+        endDate: Date | string
+    ): Promise<IBodyCompositionData> {
+        const start =
+            typeof startDate === 'string' ? startDate : toDateString(startDate);
+        const end =
+            typeof endDate === 'string' ? endDate : toDateString(endDate);
+        return this.client.get<IBodyCompositionData>(
+            this.url.BODY_COMPOSITION,
+            { params: { startDate: start, endDate: end } }
+        );
+    }
+
+    async getHrvData(date = new Date()): Promise<IHrvData> {
+        const dateString = toDateString(date);
+        return this.client.get<IHrvData>(`${this.url.HRV}/${dateString}`);
+    }
+
+    async getStressData(date = new Date()): Promise<IStressData> {
+        const dateString = toDateString(date);
+        return this.client.get<IStressData>(
+            `${this.url.DAILY_STRESS}/${dateString}`
+        );
+    }
+
+    async getBodyBattery(
+        startDate: Date | string,
+        endDate: Date | string
+    ): Promise<IBodyBatteryData[]> {
+        const start =
+            typeof startDate === 'string' ? startDate : toDateString(startDate);
+        const end =
+            typeof endDate === 'string' ? endDate : toDateString(endDate);
+        return this.client.get<IBodyBatteryData[]>(this.url.BODY_BATTERY, {
+            params: { startDate: start, endDate: end }
+        });
+    }
+
+    async getSpO2Data(date = new Date()): Promise<ISpO2Data> {
+        const dateString = toDateString(date);
+        return this.client.get<ISpO2Data>(`${this.url.SPO2}/${dateString}`);
+    }
+
+    async getFitnessAge(date = new Date()): Promise<IFitnessAgeData> {
+        const dateString = toDateString(date);
+        return this.client.get<IFitnessAgeData>(
+            `${this.url.FITNESS_AGE}/${dateString}`
+        );
+    }
+
+    async getEnduranceScore(date = new Date()): Promise<IEnduranceScoreData> {
+        const dateString = toDateString(date);
+        return this.client.get<IEnduranceScoreData>(
+            `${this.url.ENDURANCE_SCORE}/${dateString}`
+        );
+    }
+
+    async getRespirationData(date = new Date()): Promise<IRespirationData> {
+        const dateString = toDateString(date);
+        return this.client.get<IRespirationData>(
+            `${this.url.RESPIRATION}/${dateString}`
+        );
+    }
+
+    // ─── Generic Methods ─────────────────────────────────────────
 
     async get<T>(url: string, data?: any) {
         const response = await this.client.get(url, data);

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -89,6 +89,33 @@ export class UrlClass {
     get DAILY_HEART_RATE() {
         return `${this.GC_API}/wellness-service/wellness/dailyHeartRate`;
     }
+    get USER_SUMMARY() {
+        return `${this.GC_API}/usersummary-service/usersummary/daily`;
+    }
+    get BODY_COMPOSITION() {
+        return `${this.GC_API}/weight-service/weight/dateRange`;
+    }
+    get HRV() {
+        return `${this.GC_API}/hrv-service/hrv`;
+    }
+    get DAILY_STRESS() {
+        return `${this.GC_API}/wellness-service/wellness/dailyStress`;
+    }
+    get BODY_BATTERY() {
+        return `${this.GC_API}/wellness-service/wellness/bodyBattery/reports/daily`;
+    }
+    get SPO2() {
+        return `${this.GC_API}/wellness-service/wellness/daily/spo2`;
+    }
+    get FITNESS_AGE() {
+        return `${this.GC_API}/fitnessage-service/fitnessage`;
+    }
+    get ENDURANCE_SCORE() {
+        return `${this.GC_API}/metrics-service/metrics/endurancescore`;
+    }
+    get RESPIRATION() {
+        return `${this.GC_API}/wellness-service/wellness/daily/respiration`;
+    }
     WORKOUT(id?: GCWorkoutId) {
         if (id) {
             return `${this.GC_API}/workout-service/workout/${id}`;

--- a/src/garmin/types/golf.ts
+++ b/src/garmin/types/golf.ts
@@ -1,6 +1,6 @@
 // summary
 
-interface ScorecardSummary {
+export interface ScorecardSummary {
     id: number;
     customerId: string;
     playerProfileId: number;
@@ -17,7 +17,7 @@ interface ScorecardSummary {
     roundType: string;
 }
 
-interface GolfSummary {
+export interface GolfSummary {
     pageNumber: number;
     rowsPerPage: number;
     totalRows: number;
@@ -26,7 +26,7 @@ interface GolfSummary {
 
 // detail
 
-interface Hole {
+export interface Hole {
     number: number;
     strokes: number;
     penalties: number;
@@ -37,7 +37,7 @@ interface Hole {
     pinPositionLon: number;
 }
 
-interface GolfScorecard {
+export interface GolfScorecard {
     id: number;
     customerId: string;
     playerProfileId: number;

--- a/src/garmin/types/heartrate.ts
+++ b/src/garmin/types/heartrate.ts
@@ -1,14 +1,14 @@
-interface HeartRateValueDescriptor {
+export interface HeartRateValueDescriptor {
     key: string;
     index: number;
 }
 
-interface HeartRateEntry {
+export interface HeartRateEntry {
     timestamp: number;
     heartrate: number;
 }
 
-interface HeartRate {
+export interface HeartRate {
     userProfilePK: number;
     calendarDate: string;
     startTimestampGMT: string;

--- a/src/garmin/types/hydration.ts
+++ b/src/garmin/types/hydration.ts
@@ -1,4 +1,4 @@
-interface HydrationData {
+export interface HydrationData {
     userId: number;
     calendarDate: string;
     lastEntryTimestampLocal: string;
@@ -12,14 +12,14 @@ interface HydrationData {
     hydrationAutoGoalEnabled: boolean;
 }
 
-interface HydrationContainer {
+export interface HydrationContainer {
     name: string | null;
     volume: number;
     unit: string;
 }
 
 // hydration/log
-interface WaterIntake {
+export interface WaterIntake {
     userId: number;
     calendarDate: string;
     valueInML: number;

--- a/src/garmin/types/weight.ts
+++ b/src/garmin/types/weight.ts
@@ -1,6 +1,6 @@
 // weight-service/weight/dayview/2023-12-28
 
-interface DateWeight {
+export interface DateWeight {
     samplePk: number;
     date: number;
     calendarDate: string;
@@ -18,7 +18,7 @@ interface DateWeight {
     weightDelta: number;
 }
 
-interface TotalAverage {
+export interface TotalAverage {
     from: number;
     until: number;
     weight: number;
@@ -32,14 +32,14 @@ interface TotalAverage {
     metabolicAge: number | null;
 }
 
-interface WeightData {
+export interface WeightData {
     startDate: string;
     endDate: string;
     dateWeightList: DateWeight[];
     totalAverage: TotalAverage;
 }
 
-interface UpdateWeight {
+export interface UpdateWeight {
     dateTimestamp: string; // Format: "2023-12-31T12:39:00.00"
     gmtTimestamp: string; // Format: "2023-12-31T20:39:00.00"
     unitKey: string; // Example: "lbs"

--- a/src/garmin/types/wellness.ts
+++ b/src/garmin/types/wellness.ts
@@ -1,0 +1,194 @@
+// ─── User Daily Summary ──────────────────────────────────────
+export interface IUserSummary {
+    totalKilocalories?: number;
+    activeKilocalories?: number;
+    bmrKilocalories?: number;
+    consumedKilocalories?: number;
+    burnedKilocalories?: number;
+    totalSteps?: number;
+    dailyStepGoal?: number;
+    totalDistanceMeters?: number;
+    floorsAscended?: number;
+    floorsDescended?: number;
+    restingHeartRate?: number;
+    minHeartRate?: number;
+    maxHeartRate?: number;
+    minAvgHeartRate?: number;
+    maxAvgHeartRate?: number;
+    lastSevenDaysAvgRestingHeartRate?: number;
+    abnormalHeartRateAlertsCount?: number;
+    averageStressLevel?: number;
+    maxStressLevel?: number;
+    stressDuration?: number;
+    restStressDuration?: number;
+    activityStressDuration?: number;
+    lowStressDuration?: number;
+    mediumStressDuration?: number;
+    highStressDuration?: number;
+    bodyBatteryChargedValue?: number;
+    bodyBatteryDrainedValue?: number;
+    bodyBatteryHighestValue?: number;
+    bodyBatteryLowestValue?: number;
+    bodyBatteryMostRecentValue?: number;
+    averageSpo2?: number;
+    lowestSpo2?: number;
+    latestSpo2?: number;
+    highestRespirationValue?: number;
+    lowestRespirationValue?: number;
+    latestRespirationValue?: number;
+    moderateIntensityMinutes?: number;
+    vigorousIntensityMinutes?: number;
+    intensityMinutesGoal?: number;
+    highlyActiveSeconds?: number;
+    activeSeconds?: number;
+    sedentarySeconds?: number;
+    sleepingSeconds?: number;
+    measurableAwakeDuration?: number;
+    measurableAsleepDuration?: number;
+    calendarDate?: string;
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    startTimestampLocal?: number;
+    endTimestampLocal?: number;
+    [key: string]: unknown;
+}
+
+// ─── Body Composition ────────────────────────────────────────
+export interface IBodyCompositionEntry {
+    samplePk?: number;
+    date?: number;
+    calendarDate?: string;
+    weight?: number;
+    bmi?: number;
+    bodyFat?: number;
+    bodyWater?: number;
+    boneMass?: number;
+    muscleMass?: number;
+    visceralFat?: number;
+    metabolicAge?: number;
+    physiqueRating?: number;
+    sourceType?: string;
+    [key: string]: unknown;
+}
+
+export interface IBodyCompositionData {
+    startDate?: string;
+    endDate?: string;
+    dateWeightList?: IBodyCompositionEntry[];
+    totalAverage?: IBodyCompositionEntry;
+    [key: string]: unknown;
+}
+
+// ─── HRV ─────────────────────────────────────────────────────
+export interface IHrvSummary {
+    calendarDate?: string;
+    weeklyAvg?: number;
+    lastNight?: number;
+    lastNightAvg?: number;
+    lastNight5MinHigh?: number;
+    baseline?: {
+        lowUpper?: number;
+        balancedLow?: number;
+        balancedUpper?: number;
+        markerValue?: number;
+    };
+    status?: string;
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    startTimestampLocal?: number;
+    endTimestampLocal?: number;
+    [key: string]: unknown;
+}
+
+export interface IHrvData {
+    hrvSummaries?: IHrvSummary[];
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    startTimestampLocal?: number;
+    endTimestampLocal?: number;
+    [key: string]: unknown;
+}
+
+// ─── Stress ──────────────────────────────────────────────────
+export interface IStressData {
+    calendarDate?: string;
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    startTimestampLocal?: number;
+    endTimestampLocal?: number;
+    maxStressLevel?: number;
+    avgStressLevel?: number;
+    stressChartValueOffset?: number;
+    stressChartYAxisOrigin?: number;
+    stressValuesArray?: [number, number][];
+    bodyBatteryValuesArray?: [number, number][];
+    [key: string]: unknown;
+}
+
+// ─── Body Battery ────────────────────────────────────────────
+export interface IBodyBatteryEvent {
+    startTimestampGMT?: string;
+    endTimestampGMT?: string;
+    event?: string;
+    durationInMilliseconds?: number;
+    bodyBatteryImpact?: number;
+    [key: string]: unknown;
+}
+
+export interface IBodyBatteryData {
+    date?: string;
+    charged?: number;
+    drained?: number;
+    startOfDay?: number;
+    endOfDay?: number;
+    bodyBatteryEvents?: IBodyBatteryEvent[];
+    [key: string]: unknown;
+}
+
+// ─── SpO2 ────────────────────────────────────────────────────
+export interface ISpO2Data {
+    calendarDate?: string;
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    startTimestampLocal?: number;
+    endTimestampLocal?: number;
+    averageSpo2?: number;
+    lowestSpo2?: number;
+    latestSpo2?: number;
+    latestSpo2ReadingTimeGmt?: string;
+    latestSpo2ReadingTimeLocal?: string;
+    spo2HourlyAverages?: { spo2?: number; timestampGMT?: number }[];
+    [key: string]: unknown;
+}
+
+// ─── Fitness Age ─────────────────────────────────────────────
+export interface IFitnessAgeData {
+    chronologicalAge?: number;
+    fitnessAge?: number;
+    achievableFitnessAge?: number;
+    previousFitnessAge?: number;
+    bmi?: number;
+    rhr?: number;
+    vigorousMinutesWeekAvg?: number;
+    [key: string]: unknown;
+}
+
+// ─── Endurance Score ─────────────────────────────────────────
+export interface IEnduranceScoreData {
+    overallScore?: number;
+    classificationMessage?: string;
+    calendarDate?: string;
+    [key: string]: unknown;
+}
+
+// ─── Respiration ─────────────────────────────────────────────
+export interface IRespirationData {
+    calendarDate?: string;
+    startTimestampGMT?: number;
+    endTimestampGMT?: number;
+    highestRespirationValue?: number;
+    lowestRespirationValue?: number;
+    avgWakingRespirationValue?: number;
+    avgSleepRespirationValue?: number;
+    [key: string]: unknown;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
 export { default as GarminConnect } from './garmin/GarminConnect';
+export type { GCCredentials, Event, Session } from './garmin/GarminConnect';
+export { GarminMfaRequiredError } from './common/HttpClient';
+export type { MfaLoginState } from './common/HttpClient';
+export * from './garmin/types';
+export * from './garmin/types/wellness';
+export * from './garmin/types/activity';
+export * from './garmin/types/sleep';
+export * from './garmin/types/weight';
+export * from './garmin/types/heartrate';
+export * from './garmin/types/hydration';


### PR DESCRIPTION
New wellness methods: getUserSummary, getBodyComposition, getHrvData, getStressData, getBodyBattery, getSpO2Data, getFitnessAge, getEnduranceScore, getRespirationData — with full TypeScript types.

MFA support: GarminMfaRequiredError thrown on login when 2FA is required; resumeWithMfa(code) completes the OAuth flow.

All type interfaces are now exported from the package root.