### PR TITLE
feat: restore activity image methods (uploadImage, deleteImage)

### DIFF
--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -255,6 +255,37 @@ export default class GarminConnect {
         await this.client.delete<void>(this.url.ACTIVITY + activity.activityId);
     }
 
+    async uploadImage(
+        activity: { activityId: GCActivityId },
+        file: string
+    ): Promise<any> {
+        if (!activity.activityId) throw new Error('Missing activityId');
+        const fileBuffer = fs.readFileSync(file);
+        const form = new FormData();
+        form.append('file', fileBuffer, {
+            filename: path.basename(file)
+        });
+        return this.client.post(
+            this.url.ACTIVITY_IMAGE(activity.activityId),
+            form,
+            {
+                headers: {
+                    'Content-Type': form.getHeaders()['content-type']
+                }
+            }
+        );
+    }
+
+    async deleteImage(
+        activity: { activityId: GCActivityId },
+        imageId: string
+    ): Promise<void> {
+        if (!activity.activityId) throw new Error('Missing activityId');
+        await this.client.delete<void>(
+            this.url.ACTIVITY_IMAGE_DELETE(activity.activityId, imageId)
+        );
+    }
+
     async getWorkouts(start: number, limit: number): Promise<IWorkout[]> {
         return this.client.get<IWorkout[]>(this.url.WORKOUTS, {
             params: {

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -1,4 +1,5 @@
 import { GCWorkoutId, GarminDomain } from './types';
+import { GCActivityId } from './types/activity';
 
 export class UrlClass {
     private domain: GarminDomain;
@@ -40,6 +41,12 @@ export class UrlClass {
     }
     get ACTIVITY() {
         return `${this.GC_API}/activity-service/activity/`;
+    }
+    ACTIVITY_IMAGE(activityId: GCActivityId) {
+        return `${this.GC_API}/activity-service/activity/${activityId}/image`;
+    }
+    ACTIVITY_IMAGE_DELETE(activityId: GCActivityId, imageId: string) {
+        return `${this.GC_API}/activity-service/activity/${activityId}/image/${imageId}`;
     }
     get STAT_ACTIVITIES() {
         return `${this.GC_API}/fitnessstats-service/activity`;


### PR DESCRIPTION
Re-implements activity image upload/delete lost during v1.6.0 rewrite. Original implementation by florianpasteur in PR #45.