### PR TITLE
feat: restore social connections, device info, and news feed methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,36 +148,32 @@ There's currently no way of removing listeners.
 
 ## Reading data
 
-### User info is not implemented yet. // TODO: Implement this function
+### `getSocialConnections(): Promise<ISocialConnections>`
 
-Receive basic user information
-
-```js
-GCClient.getUserInfo();
-```
-
-### Social Profile is not implemented yet. // TODO: Implement this function
-
-Receive social user information
+Get a list of all social connections.
 
 ```js
-GCClient.getSocialProfile();
+const connections = await GCClient.getSocialConnections();
+console.log(connections.userConnections);
 ```
 
-### Social Connections is not implemented yet. // TODO: Implement this function
-
-Get a list of all social connections
-
-```js
-GCClient.getSocialConnections();
-```
-
-### Device info is not implemented yet. // TODO: Implement this function
+### `getDeviceInfo(): Promise<any[]>`
 
 Get a list of all registered devices including model numbers and firmware versions.
 
 ```js
-GCClient.getDeviceInfo();
+const devices = await GCClient.getDeviceInfo();
+```
+
+### `getNewsFeed(start?: number, limit?: number): Promise<any[]>`
+
+Get a list of activities in your news feed.
+
+```js
+// Get the news feed with default length
+const feed = await GCClient.getNewsFeed();
+// Get activities in feed, 10 through 15
+const feedPage = await GCClient.getNewsFeed(10, 5);
 ```
 
 ### `getActivities(start: number, limit: number, activityType?: ActivityType, subActivityType?: ActivitySubType): Promise<IActivity[]>`
@@ -226,17 +222,6 @@ Retrieves details for a specific activity based on the provided `activityId`.
 const activityDetails = await GCClient.getActivity({
     activityId: 'exampleActivityId'
 });
-```
-
-### News Feed is not implemented yet. // TODO: Implement this function
-
-To get a list of activities in your news feed, use the `getNewsFeed` method. This function takes two arguments, _start_ and _limit_, which is used for pagination. Both are optional and will default to whatever Garmin Connect is using. To be sure to get all activities, use this correctly.
-
-```js
-// Get the news feed with a default length with most recent activities
-GCClient.getNewsFeed();
-// Get activities in feed, 10 through 15. (start 10, limit 5)
-GCClient.getNewsFeed(10, 5);
 ```
 
 ### Download original activity data

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -17,6 +17,7 @@ import {
     IGarminTokens,
     IOauth1Token,
     IOauth2Token,
+    ISocialConnections,
     ISocialProfile,
     IUserSettings,
     IWorkout,
@@ -96,6 +97,14 @@ export default class GarminConnect {
         );
         return this;
     }
+
+    async getDisplayName(): Promise<string> {
+        if (this._userHash) return this._userHash;
+        const profile = await this.getUserProfile();
+        this._userHash = profile.displayName;
+        return this._userHash;
+    }
+
     exportTokenToFile(dirPath: string): void {
         if (!checkIsDirectory(dirPath)) {
             createDirectory(dirPath);
@@ -533,6 +542,24 @@ export default class GarminConnect {
         } catch (error: any) {
             throw new Error(`Error in getHeartRate: ${error.message}`);
         }
+    }
+
+    async getSocialConnections(): Promise<ISocialConnections> {
+        const displayName = await this.getDisplayName();
+        return this.client.get<ISocialConnections>(
+            this.url.SOCIAL_CONNECTIONS(displayName)
+        );
+    }
+
+    async getDeviceInfo(): Promise<any[]> {
+        const displayName = await this.getDisplayName();
+        return this.client.get<any[]>(this.url.DEVICE_INFO(displayName));
+    }
+
+    async getNewsFeed(start?: number, limit?: number): Promise<any[]> {
+        return this.client.get<any[]>(this.url.NEWS_FEED, {
+            params: { start, limit }
+        });
     }
 
     async get<T>(url: string, data?: any) {

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -35,6 +35,15 @@ export class UrlClass {
     get USER_PROFILE() {
         return `${this.GC_API}/userprofile-service/socialProfile`;
     }
+    SOCIAL_CONNECTIONS(displayName: string) {
+        return `${this.GC_API}/userprofile-service/socialProfile/connections/${displayName}`;
+    }
+    DEVICE_INFO(displayName: string) {
+        return `${this.GC_API}/device-service/deviceservice/device-info/all/${displayName}`;
+    }
+    get NEWS_FEED() {
+        return `${this.GC_API}/activitylist-service/activities/subscriptionFeed`;
+    }
     get ACTIVITIES() {
         return `${this.GC_API}/activitylist-service/activities/search/activities`;
     }


### PR DESCRIPTION
Re-implements getSocialConnections, getDeviceInfo, and getNewsFeed lost during v1.6.0 rewrite. Adds getDisplayName() helper for endpoints requiring the user hash. Original implementations from PR #6 and commit 4e8c2a6.