### PR TITLE
feat: restore badge API methods (getBadgesEarned, getBadgesAvailable,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,40 @@ Retrieves daily heart rate data for a given date.
 const heartRateData = await GCClient.getHeartRate(new Date('2020-03-24'));
 ```
 
+### `getBadgesEarned(): Promise<IBadge[]>`
+
+Retrieves a list of all badges earned by the user.
+
+#### Example:
+
+```js
+const badges = await GCClient.getBadgesEarned();
+```
+
+### `getBadgesAvailable(): Promise<IBadge[]>`
+
+Retrieves a list of all available badges.
+
+#### Example:
+
+```js
+const availableBadges = await GCClient.getBadgesAvailable();
+```
+
+### `getBadgeDetail(badgeId: number): Promise<IBadge>`
+
+Retrieves details for a specific badge.
+
+#### Parameters:
+
+-   `badgeId` (number): Identifier for the desired badge.
+
+#### Example:
+
+```js
+const badge = await GCClient.getBadgeDetail(123);
+```
+
 ## Modifying data
 
 ### Update activity is not implemented yet. // TODO: Implement this function

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -10,8 +10,10 @@ import { checkIsDirectory, createDirectory, writeToFile } from '../utils';
 import { UrlClass } from './UrlClass';
 import {
     ExportFileTypeValue,
+    GCBadgeId,
     GCUserHash,
     GarminDomain,
+    IBadge,
     ICountActivities,
     IDailyStepsType,
     IGarminTokens,
@@ -533,6 +535,19 @@ export default class GarminConnect {
         } catch (error: any) {
             throw new Error(`Error in getHeartRate: ${error.message}`);
         }
+    }
+
+    async getBadgesEarned(): Promise<IBadge[]> {
+        return this.client.get<IBadge[]>(this.url.BADGES_EARNED);
+    }
+
+    async getBadgesAvailable(): Promise<IBadge[]> {
+        return this.client.get<IBadge[]>(this.url.BADGES_AVAILABLE);
+    }
+
+    async getBadgeDetail(badgeId: GCBadgeId): Promise<IBadge> {
+        if (!badgeId) throw new Error('Missing badgeId');
+        return this.client.get<IBadge>(this.url.BADGE_DETAIL(badgeId));
     }
 
     async get<T>(url: string, data?: any) {

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -1,4 +1,4 @@
-import { GCWorkoutId, GarminDomain } from './types';
+import { GCBadgeId, GCWorkoutId, GarminDomain } from './types';
 
 export class UrlClass {
     private domain: GarminDomain;
@@ -88,6 +88,15 @@ export class UrlClass {
     }
     get DAILY_HEART_RATE() {
         return `${this.GC_API}/wellness-service/wellness/dailyHeartRate`;
+    }
+    get BADGES_EARNED() {
+        return `${this.GC_API}/badge-service/badge/earned`;
+    }
+    get BADGES_AVAILABLE() {
+        return `${this.GC_API}/badge-service/badge/available`;
+    }
+    BADGE_DETAIL(id: GCBadgeId) {
+        return `${this.GC_API}/badge-service/badge/detail/v2/${id}`;
     }
     WORKOUT(id?: GCWorkoutId) {
         if (id) {


### PR DESCRIPTION
… getBadgeDetail)

Re-implements badge methods lost during v1.6.0 rewrite. Original implementation by wscourge in PR #44. Types IBadge, IBadgeRelated, GCBadgeId already existed — adds URL getters and client methods.