### PR TITLE
feat: restore gear API methods (getGear, linkGearToActivity, unlinkGe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,42 @@ Retrieves daily heart rate data for a given date.
 const heartRateData = await GCClient.getHeartRate(new Date('2020-03-24'));
 ```
 
+### `getGear(userProfilePk: number): Promise<Gear[]>`
+
+Retrieves all gear for the user.
+
+#### Parameters:
+
+-   `userProfilePk` (number): User profile primary key (from `getUserSettings().id`).
+
+#### Example:
+
+```js
+const settings = await GCClient.getUserSettings();
+const gear = await GCClient.getGear(settings.id);
+```
+
+### `linkGearToActivity(activityId: GCActivityId, gearUuid: string): Promise<Gear>`
+
+Links a gear item to an activity.
+
+#### Example:
+
+```js
+const gear = await GCClient.getGear(settings.id);
+await GCClient.linkGearToActivity(activityId, gear[0].uuid);
+```
+
+### `unlinkGearFromActivity(activityId: GCActivityId, gearUuid: string): Promise<Gear>`
+
+Unlinks a gear item from an activity.
+
+#### Example:
+
+```js
+await GCClient.unlinkGearFromActivity(activityId, gear[0].uuid);
+```
+
 ## Modifying data
 
 ### Update activity is not implemented yet. // TODO: Implement this function

--- a/src/garmin/GarminConnect.ts
+++ b/src/garmin/GarminConnect.ts
@@ -11,6 +11,7 @@ import { UrlClass } from './UrlClass';
 import {
     ExportFileTypeValue,
     GCUserHash,
+    Gear,
     GarminDomain,
     ICountActivities,
     IDailyStepsType,
@@ -533,6 +534,30 @@ export default class GarminConnect {
         } catch (error: any) {
             throw new Error(`Error in getHeartRate: ${error.message}`);
         }
+    }
+
+    async getGear(userProfilePk: number): Promise<Gear[]> {
+        return this.client.get<Gear[]>(this.url.GEAR(userProfilePk));
+    }
+
+    async linkGearToActivity(
+        activityId: GCActivityId,
+        gearUuid: string
+    ): Promise<Gear> {
+        return this.client.put<Gear>(
+            this.url.LINK_GEAR(gearUuid, activityId),
+            {}
+        );
+    }
+
+    async unlinkGearFromActivity(
+        activityId: GCActivityId,
+        gearUuid: string
+    ): Promise<Gear> {
+        return this.client.put<Gear>(
+            this.url.UNLINK_GEAR(gearUuid, activityId),
+            {}
+        );
     }
 
     async get<T>(url: string, data?: any) {

--- a/src/garmin/UrlClass.ts
+++ b/src/garmin/UrlClass.ts
@@ -1,4 +1,5 @@
 import { GCWorkoutId, GarminDomain } from './types';
+import { GCActivityId } from './types/activity';
 
 export class UrlClass {
     private domain: GarminDomain;
@@ -88,6 +89,15 @@ export class UrlClass {
     }
     get DAILY_HEART_RATE() {
         return `${this.GC_API}/wellness-service/wellness/dailyHeartRate`;
+    }
+    GEAR(userProfilePk: number) {
+        return `${this.GC_API}/gear-service/gear/filterGear?userProfilePk=${userProfilePk}`;
+    }
+    LINK_GEAR(gearUuid: string, activityId: GCActivityId) {
+        return `${this.GC_API}/gear-service/gear/link/${gearUuid}/activity/${activityId}`;
+    }
+    UNLINK_GEAR(gearUuid: string, activityId: GCActivityId) {
+        return `${this.GC_API}/gear-service/gear/unlink/${gearUuid}/activity/${activityId}`;
     }
     WORKOUT(id?: GCWorkoutId) {
         if (id) {


### PR DESCRIPTION
…arFromActivity)

Re-implements gear methods lost during v1.6.0 rewrite. Original implementation by florianpasteur in PR #46. Gear type already existed — adds URL builders and client methods.